### PR TITLE
Minor reversion to scoping

### DIFF
--- a/R/instance-templating.R
+++ b/R/instance-templating.R
@@ -79,7 +79,7 @@ manage_data <- function(..., instance_object) {
 manage_scoping <- function(element, instance_object) {
     if (length(instance_object$component$styles$scoped) > 0L) {
         args <- alist("")
-        names(args) <- paste0("data-rsx-", instance_object$component$name)
+        names(args) <- paste0("data-rsx-", attr(instance_object$component, "component_id"))
         htmltools::tagQuery(wrap_tags(element))$
             each(function(x, i) add_scoping(x, i, args))$
             find("*")$

--- a/tests/testthat/test_3-component-template.R
+++ b/tests/testthat/test_3-component-template.R
@@ -42,6 +42,20 @@ test_that(
 test_that("slotting", {
     reset_rsx_env()
     x <- component(
+        template = function(ns) {
+            shiny::tagList(
+                shiny::tags$slot(),
+                shiny::tags$slot(name = "a")
+            )
+        }
+    )
+    expect_identical(
+        get_tag_output(x()),
+        ""
+    )
+
+    reset_rsx_env()
+    x <- component(
         name = "slot_test1",
         template = function(ns) {
             shiny::tagList(

--- a/tests/testthat/test_4-component-styles.R
+++ b/tests/testthat/test_4-component-styles.R
@@ -48,7 +48,12 @@ test_that("scoped styles", {
 
     expect_identical(
         get_tag_output(x()),
-        get_tag_output(shiny::div("data-rsx-test" = ""))
+        sprintf('<div data-rsx-%s=""></div>', attr(x, "component_id"))
+    )
+
+    expect_identical(
+        aggregate_styles(),
+        sprintf('*[data-rsx-%s=\"\"] { color: red }', attr(x, "component_id"))
     )
 })
 


### PR DESCRIPTION
- Scoping once again uses component id rather than component name
- New test for empty slots
- New test for style output