### PR TITLE
Fix no-instantiation when not printed

### DIFF
--- a/R/instance-template.R
+++ b/R/instance-template.R
@@ -24,13 +24,15 @@ template_tag <- function(instance_object, template, contents, .noWS = NULL) {
         .noWS = .noWS
     )
 
+    el <- template(
+        ns = set_namespace(instance_object$instance_id)
+    )
+
     hooks <- list(
         function(element) {
             element$name <- "component"
             children <- element[["children"]]
-            element$children <- template(
-                ns = set_namespace(instance_object$instance_id)
-            )
+            element$children <- el
             element <- manage_slots(element, children, instance_object)
             # return element children as the node is
             # wrapped in a template node

--- a/R/styles.R
+++ b/R/styles.R
@@ -2,7 +2,6 @@ postfix_css <- function(css, hash) {
     tryCatch(
         expr = {
             css <- gsub("\r?\n|\r", "", css)
-
             rsx_env$js$call("scopeComponentCSS", css, hash)
         },
         warning = function(w) {
@@ -65,8 +64,7 @@ compile_styles <- function(static_path = NULL) {
 aggregate_styles <- function() {
     css <- list()
     components <- instances_to_component_list()
-    for (id in names(components)) {
-        comp <- components[[id]]
+    for (comp in components) {
         if (!is.null(comp$styles)) {
             css <- append(css, comp$styles)
         }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,9 +4,9 @@
         ns[["rsx_env"]] <- new.env(
             parent = asNamespace("rsx")
         )
-        rsx_env[["components"]] <- list()
-        rsx_env[["instances"]] <- list()
     }
+    rsx_env[["components"]] <- list()
+    rsx_env[["instances"]] <- list()
 
     if (is.null(rsx_env[["js"]])) {
         rsx_env[["js"]] <- V8::v8(

--- a/tests/testthat/test_4-component-styles.R
+++ b/tests/testthat/test_4-component-styles.R
@@ -74,6 +74,27 @@ test_that("styles should be overwritten with same-named components", {
     })
 })
 
+test_that("styles are compiled for each used component", {
+    suppressMessages({
+        reset_rsx_env()
+        x <- component(
+            name = "x",
+            template = function(ns) {
+                y()
+            }
+        )
+        y <- component(
+            name = "y",
+            template = function(ns) {
+                "Hello world"
+            },
+            styles = "* { color: blue }"
+        )
+        x()
+        expect_true(grepl("color: blue", aggregate_styles()))
+    })
+})
+
 test_that("styles are compiled even when component is created from a method", {
     suppressMessages({
         reset_rsx_env()

--- a/tests/testthat/test_4-component-styles.R
+++ b/tests/testthat/test_4-component-styles.R
@@ -39,7 +39,7 @@ test_that("scoped styles", {
         template = function(ns) {
             shiny::div()
         },
-        styles =  "* { color: red }"
+        styles = "* { color: red }"
     )
 
     expect_identical(
@@ -75,48 +75,17 @@ test_that("styles should be overwritten with same-named components", {
 })
 
 test_that("styles are compiled for each used component", {
-    suppressMessages({
-        reset_rsx_env()
-        x <- component(
-            name = "x",
-            template = function(ns) {
-                y()
-            }
-        )
-        y <- component(
-            name = "y",
-            template = function(ns) {
-                "Hello world"
-            },
-            styles = "* { color: blue }"
-        )
-        x()
-        expect_true(grepl("color: blue", aggregate_styles()))
-    })
-})
-
-test_that("styles are compiled even when component is created from a method", {
-    suppressMessages({
-        reset_rsx_env()
-        x <- component(
-            name = "x",
-            template = function(ns) {
-                self$new_y()
-            },
-            methods = list(
-                new_y = function() {
-                    y()
-                }
-            )
-        )
-        y <- component(
-            name = "y",
-            template = function(ns) {
-                "Hello world"
-            },
-            styles = "* { color: blue }"
-        )
-        x()
-        expect_true(grepl("color: blue", aggregate_styles()))
-    })
+    reset_rsx_env()
+    comp1 <- component(
+        name = "comp1",
+        template = function(ns) {
+            comp2()
+        }
+    )
+    comp2 <- component(
+        name = "comp2",
+        styles = "* { color: blue }"
+    )
+    comp1()
+    expect_true(grepl("color: blue", aggregate_styles()))
 })

--- a/tests/testthat/test_4-component-styles.R
+++ b/tests/testthat/test_4-component-styles.R
@@ -73,3 +73,29 @@ test_that("styles should be overwritten with same-named components", {
         expect_true(grepl("color: blue", styles))
     })
 })
+
+test_that("styles are compiled even when component is created from a method", {
+    suppressMessages({
+        reset_rsx_env()
+        x <- component(
+            name = "x",
+            template = function(ns) {
+                self$new_y()
+            },
+            methods = list(
+                new_y = function() {
+                    y()
+                }
+            )
+        )
+        y <- component(
+            name = "y",
+            template = function(ns) {
+                "Hello world"
+            },
+            styles = "* { color: blue }"
+        )
+        x()
+        expect_true(grepl("color: blue", aggregate_styles()))
+    })
+})

--- a/tests/testthat/test_7-misc.R
+++ b/tests/testthat/test_7-misc.R
@@ -45,7 +45,6 @@ test_that("withTags", {
             template = function(ns) {
                 shiny::withTags(
                     shiny::tagList(
-                        x(),
                         p("Bar")
                     )
                 )


### PR DESCRIPTION
Template was only called from the render hook which meant that instantiation could only occur when the object was printed.